### PR TITLE
[HLSL] Make trunct overload tests stricter NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/trunc-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/trunc-overloads.hlsl
@@ -1,83 +1,107 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm  -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z17test_trunc_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.trunc.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_trunc_double(double p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_trunc_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.trunc.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_trunc_double2(double2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_trunc_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.trunc.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_trunc_double3(double3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_trunc_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.trunc.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_trunc_double4(double4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z14test_trunc_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_trunc_int(int p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_trunc_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_trunc_int2(int2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_trunc_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_trunc_int3(int3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_trunc_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_trunc_int4(int4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z15test_trunc_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_trunc_uint(uint p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_trunc_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_trunc_uint2(uint2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_trunc_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_trunc_uint3(uint3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_trunc_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_trunc_uint4(uint4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z18test_trunc_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_trunc_int64_t(int64_t p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_trunc_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_trunc_int64_t2(int64_t2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_trunc_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_trunc_int64_t3(int64_t3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_trunc_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_trunc_int64_t4(int64_t4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z19test_trunc_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_trunc_uint64_t(uint64_t p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_trunc_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_trunc_uint64_t2(uint64_t2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_trunc_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_trunc_uint64_t3(uint64_t3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_trunc_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_trunc_uint64_t4(uint64_t4 p0) { return trunc(p0); }


### PR DESCRIPTION
This patch updates trunc overload tests to use -O1 instead of -disable-llvm-passes; also, the checks are updated to match the change accordingly.

This work is part of https://github.com/llvm/llvm-project/issues/138016.